### PR TITLE
feat: redirect to app url

### DIFF
--- a/web-assets/auth0/dev-tenant/rules/onboardingChecklist.js
+++ b/web-assets/auth0/dev-tenant/rules/onboardingChecklist.js
@@ -125,7 +125,7 @@ function (user, context, callback) {
                             }
                         }
                     }
-        
+
                     const profileCompletedData = onboardingChecklistTrait.data.length > 0 ? onboardingChecklistTrait.data[0].profile_completed : null;
         
                     if (profileCompletedData) {

--- a/web-assets/js/setupAuth0WithRedirect.js
+++ b/web-assets/js/setupAuth0WithRedirect.js
@@ -233,7 +233,7 @@ const authSetup = function () {
 
     const redirectToOnboardingWizard = function () {
         logger("redirect to onboarding wizard");
-        window.location = onboardingWizardUrl;
+        window.location = onboardingWizardUrl
     }
 
     const redirectToApp = function () {
@@ -319,7 +319,7 @@ const authSetup = function () {
                         logger('Need to persist appUrl', returnAppUrl)
                         setCookie('returnAfterOnboard', returnAppUrl) // TODO: use localStorage instead?
                     }
-                    redirectToOnboardingWizard();
+                    redirectToOnboardingWizard(returnAppUrl);
                 } 
                 else {
                     // session still active, but app calling login

--- a/web-assets/js/setupAuth0WithRedirect.js
+++ b/web-assets/js/setupAuth0WithRedirect.js
@@ -271,9 +271,9 @@ const authSetup = function () {
             let showOnboardingWizard = false;
             Object.keys(claims).forEach(key => {
                 logger('Checking key', key);
-                if (key.indexOf('show_onboarding_wizard') !== -1) {
-                    if (claims[key]) {
-                        showOnboardingWizard = true;
+                if (key.indexOf('onboarding_wizard') !== -1) {
+                    if (claims[key] === 'show' || claims[key] === 'override') {
+                        showOnboardingWizard = claims[key];
                     }
                 }
             });
@@ -314,9 +314,14 @@ const authSetup = function () {
                 }
 
                 if (showOnboardingWizard) {
-                    logger('Take user to onboarding wizard');
+                    logger('Take user to onboarding wizard', showOnboardingWizard);
+                    if (showOnboardingWizard === 'retUrl') {
+                        logger('Need to persist appUrl', returnAppUrl)
+                        setCookie('returnAfterOnboard', returnAppUrl) // TODO: use localStorage instead?
+                    }
                     redirectToOnboardingWizard();
-                } else {    
+                } 
+                else {
                     // session still active, but app calling login
                     if (!appUrl && returnAppUrl) {
                         appUrl = returnAppUrl


### PR DESCRIPTION
we now have three separate flows depending on the registration source

1. registration sources that take user to the onboarding app and at the end of the process takes user to /home
2. registration sources that take user to the onboarding app but at the end of the process takes user to the URL they signed up from
3. registration sources that doesn't require user to go through the onboarding process